### PR TITLE
Bubble `infinite-scroll-fetch` from component up to window

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,6 @@ function handleInfiniteScrollFetchRequest() {
     // add to infinite scroll container
 }
 
-window.addEventListener('infinite-scroll-fetch', handleInfiniteScrollFetchRequest);
+const infiniteScrollElem = document.querySelector('infinite-scroll');
+infiniteScrollElem.addEventListener('infinite-scroll-fetch', handleInfiniteScrollFetchRequest);
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "infinite-scroll-component",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.15.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "infinite-scroll-component",
   "type": "module",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A little web component for infinite scrolling.",
   "main": "index.js",
   "dependencies": {},

--- a/src/infinite-scroll.js
+++ b/src/infinite-scroll.js
@@ -68,10 +68,14 @@ export default class InfiniteScroll extends HTMLElement {
             return;
         }
         if (height) {
-            this.divContentElem.addEventListener('scroll', this.boundScrollTick);
+            this.divContentElem.addEventListener('scroll', this.boundScrollTick, {
+                passive: true,
+            });
             window.removeEventListener('scroll', this.boundScrollTick);
         } else {
-            window.addEventListener('scroll', this.boundScrollTick);
+            window.addEventListener('scroll', this.boundScrollTick, {
+                passive: true,
+            });
             this.divContentElem.removeEventListener('scroll', this.boundScrollTick);
         }
         this.divContentElem.style.height = height;
@@ -90,9 +94,14 @@ export default class InfiniteScroll extends HTMLElement {
 
             if (currentThreshold >= this.thresholdLimit) {
                 if (!this.hasBreachedThreshold) {
-                    const event = new Event('infinite-scroll-fetch');
+                    const event = new CustomEvent('infinite-scroll-fetch', {
+                        detail: {
+                            elem: this,
+                        },
+                        bubbles: true,
+                    });
                     this.hasBreachedThreshold = true;
-                    window.dispatchEvent(event);
+                    this.dispatchEvent(event);
                 }
             } else {
                 this.hasBreachedThreshold = false;

--- a/tests/infinite-scroll.test.js
+++ b/tests/infinite-scroll.test.js
@@ -87,7 +87,9 @@ describe('infinite-scroll Tests', () => {
             infiniteScroll.setDivContainerHeight(null);
     
             expect(infiniteScroll.divContentElem.style.height).toEqual('');
-            expect(windowAddEventListenerSpy).toHaveBeenCalledWith('scroll', infiniteScroll.boundScrollTick);
+            expect(windowAddEventListenerSpy).toHaveBeenCalledWith('scroll', infiniteScroll.boundScrollTick, {
+                passive: true,
+            });
             expect(divContentElemRemoveEventListenerSpy).toHaveBeenCalledWith('scroll', infiniteScroll.boundScrollTick);
             expect(infiniteScroll.divContentElem.style.height).toEqual('');
         });
@@ -103,7 +105,9 @@ describe('infinite-scroll Tests', () => {
             infiniteScroll.setDivContainerHeight('200px');
     
             expect(infiniteScroll.divContentElem.style.height).toEqual('200px');
-            expect(divContentElemAddEventListenerSpy).toHaveBeenCalledWith('scroll', infiniteScroll.boundScrollTick);
+            expect(divContentElemAddEventListenerSpy).toHaveBeenCalledWith('scroll', infiniteScroll.boundScrollTick, {
+                passive: true,
+            });
             expect(windowRemoveEventListenerSpy).toHaveBeenCalledWith('scroll', infiniteScroll.boundScrollTick);
             expect(infiniteScroll.divContentElem.style.height).toEqual('200px');
         });
@@ -205,9 +209,9 @@ describe('infinite-scroll Tests', () => {
         });
 
         it('can fire event when threshold is met, no container height set', () => {
-            const dispatchEventSpy = jest.spyOn(window, 'dispatchEvent');
             const requestAnimationFrameSpy = jest.spyOn(window, 'requestAnimationFrame');
             const infiniteScroll = new InfinteScroll();
+            const dispatchEventSpy = jest.spyOn(infiniteScroll, 'dispatchEvent');
 
             infiniteScroll.connectedCallback();
             infiniteScroll.scrollTick();
@@ -255,9 +259,9 @@ describe('infinite-scroll Tests', () => {
         });
 
         it('can fire event when threshold is met, container height set', () => {
-            const dispatchEventSpy = jest.spyOn(window, 'dispatchEvent');
             const requestAnimationFrameSpy = jest.spyOn(window, 'requestAnimationFrame');
             const infiniteScroll = new InfinteScroll();
+            const dispatchEventSpy = jest.spyOn(infiniteScroll, 'dispatchEvent');
 
             infiniteScroll.connectedCallback();
             infiniteScroll.scrollTick();
@@ -282,9 +286,9 @@ describe('infinite-scroll Tests', () => {
         });
 
         it('can avoid firing event again once it has already been fired when threshold was met', () => {
-            const dispatchEventSpy = jest.spyOn(window, 'dispatchEvent');
             const requestAnimationFrameSpy = jest.spyOn(window, 'requestAnimationFrame');
             const infiniteScroll = new InfinteScroll();
+            const dispatchEventSpy = jest.spyOn(infiniteScroll, 'dispatchEvent');
 
             infiniteScroll.connectedCallback();
             infiniteScroll.scrollTick();


### PR DESCRIPTION
- Use event bubbling for `infinite-scroll-fetch` custom event
- Move from `Event` -> [`CustomEvent`](https://devdocs.io/dom/customevent)
    - `CustomEvent` detail payload contains reference to `infinite-scroll` component
- Add [`passive: true` to `scroll`](https://devdocs.io/dom/eventtarget/addeventlistener#improving_scrolling_performance_with_passive_listeners) event handlers
- Tweak Readme example